### PR TITLE
style: add same components on signup page from sing in page

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,17 +3,17 @@ import { ThemeProvider } from "./components/shared/ThemeProvider";
 import ChooseInterestPage from "./pages/Authentication/ChooseInterestPage/ChooseInterestPage";
 import LoginPage from "./pages/Authentication/LoginPage/LoginPage";
 import SignUpPage from "./pages/Authentication/SignUpPage/SignUpPage";
-import UserById from "./pages/UserById";
+// import UserById from "./pages/UserById";
 
 const routes = createBrowserRouter([
   {
     path: "/",
     element: <LoginPage />,
   },
-  {
-    path: "user/:userId",
-    element: <UserById />,
-  },
+  // {
+  //   path: "user/:userId",
+  //   element: <UserById />,
+  // },
   {
     path: "auth",
     children: [

--- a/packages/client/src/components/shared/LoginWithGoogle.tsx
+++ b/packages/client/src/components/shared/LoginWithGoogle.tsx
@@ -1,0 +1,17 @@
+const LoginWithGoogle = () => {
+  return (
+    <div className="flex flex-col items-center mt-10 text-center text-gray-600">
+      <p>Or</p>
+      <button type="button" className="flex items-center mt-5 rounded-full bg-background text-primary px-5 py-2 hover:bg-secondary transition duration-300">
+        <img
+          alt="Google Logo"
+          className="w-6 mr-2"
+          src="https://th.bing.com/th/id/R.0fa3fe04edf6c0202970f2088edea9e7?rik=joOK76LOMJlBPw&riu=http%3a%2f%2fpluspng.com%2fimg-png%2fgoogle-logo-png-open-2000.png&ehk=0PJJlqaIxYmJ9eOIp9mYVPA4KwkGo5Zob552JPltDMw%3d&risl=&pid=ImgRaw&r=0"
+        />
+        Login with Google
+      </button>
+    </div>
+  );
+};
+
+export default LoginWithGoogle;

--- a/packages/client/src/pages/Authentication/LoginPage/LoginPage.tsx
+++ b/packages/client/src/pages/Authentication/LoginPage/LoginPage.tsx
@@ -1,8 +1,8 @@
+import LoginWithGoogle from "@/components/shared/LoginWithGoogle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 function LoginPage() {
- 
   return (
     <div className="h-screen flex items-center justify-center bg-background">
       {/* Left Side (Background Image and Text) */}
@@ -28,17 +28,7 @@ function LoginPage() {
               </Button>
             </div>
           </form>
-          <div className="flex flex-col items-center mt-10 text-center text-gray-600">
-            <p>Or</p>
-            <button type="button" className="flex items-center mt-5 rounded-full bg-background text-primary px-5 py-2 hover:bg-secondary transition duration-300">
-              <img
-                alt="Google Logo"
-                className="w-6 mr-2"
-                src="https://th.bing.com/th/id/R.0fa3fe04edf6c0202970f2088edea9e7?rik=joOK76LOMJlBPw&riu=http%3a%2f%2fpluspng.com%2fimg-png%2fgoogle-logo-png-open-2000.png&ehk=0PJJlqaIxYmJ9eOIp9mYVPA4KwkGo5Zob552JPltDMw%3d&risl=&pid=ImgRaw&r=0"
-              />
-              Login with Google
-            </button>
-          </div>
+          <LoginWithGoogle />
           <div className="mt-10 text-center text-gray-600">
             <p>
               Don't have an account?{" "}

--- a/packages/client/src/pages/Authentication/SignUpPage/SignUpPage.tsx
+++ b/packages/client/src/pages/Authentication/SignUpPage/SignUpPage.tsx
@@ -1,57 +1,60 @@
 // This is sign-up page
+import LoginWithGoogle from "@/components/shared/LoginWithGoogle";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import "./SignUpPage.css";
+
 function SignUpPage() {
   return (
     <>
       <div className="min-h-screen max-h-screen flex justify-center items-center text-gray-800" id="back">
-      <div className="border-2 flex flex-col lg:flex-row w-1/2 lg:w-8/12 bg-background rounded-xl mx-auto shadow-lg overflow-hidden">
-            <div className="w-full lg:w-1/2 flex flex-col items-center justify-center p-12 bg-no-repeat bg-cover bg-center" id="backImage">
-              <h1 className="text-primary text-3xl mb-3">Welcome to Intellectia</h1>
-              <div>
-                <p className="text-primary text-center">
-                  Your guardian against misleading AI-Generated content{" "}
-                  <a href="#" className="text-stone-400 font-semibold">
-                    Learn more
-                  </a>
-                </p>
-              </div>
-            </div>
-            <div className="w-full lg:w-1/2 py-16 px-12 text-primary">
-              <h2 className="text-3xl mb-4">Register</h2>
-              <p className="mb-4 text-text">Create your account. It’s free and only takes a minute</p>
-              <form action="#">
-                <div className="grid grid-cols-2 gap-5">
-                  <input type="text" placeholder="Firstname" className="border rounded border-gray-400 py-1 px-2" />
-                  <input type="text" placeholder="Surname" className="border rounded border-gray-400 py-1 px-2" />
-                </div>
-                <div className="mt-5">
-                  <input type="text" placeholder="Email" className="border rounded border-gray-400 py-1 px-2 w-full" />
-                </div>
-                <div className="mt-5">
-                  <input type="password" placeholder="Password" className="border rounded border-gray-400 py-1 px-2 w-full" />
-                </div>
-                <div className="mt-5">
-                  <input type="password" placeholder="Confirm Password" className="border rounded border-gray-400 py-1 px-2 w-full" />
-                </div>
-                <div className="mt-5 flex gap-3 items-center">
-                  <input title="I accept" type="checkbox" className="border border-gray-400" />
-                  <span>
-                    I accept the{" "}
-                    <a href="#" className="text-stone-500 font-semibold">
-                      Terms of Use
-                    </a>{" "}
-                    &{" "}
-                    <a href="#" className="text-stone-500 font-semibold">
-                      Privacy Policy
-                    </a>
-                  </span>
-                </div>
-                <div className="mt-5">
-                  <button className="w-full rounded bg-stone-900 py-3 text-center text-white hover:bg-stone-800">Register Now</button>
-                </div>
-              </form>
+        <div className="border-2 flex flex-col lg:flex-row w-1/2 lg:w-8/12 bg-background rounded-xl mx-auto shadow-lg overflow-hidden">
+          <div className="w-full lg:w-1/2 flex flex-col items-center justify-center p-12 bg-no-repeat bg-cover bg-center" id="backImage">
+            <h1 className="text-primary text-3xl mb-3">Welcome to Intellectia</h1>
+            <div>
+              <p className="text-primary text-center">
+                Your guardian against misleading AI-Generated content{" "}
+                <a href="#" className="text-stone-400 font-semibold">
+                  Learn more
+                </a>
+              </p>
             </div>
           </div>
+          <div className="w-full lg:w-1/2 py-16 px-12 text-primary">
+            <h2 className="text-3xl mb-4">Register</h2>
+            <p className="mb-4 text-text">Create your account. It’s free and only takes a minute</p>
+            <form action="#">
+              <div className="flex flex-col space-y-2">
+                <div className="grid grid-cols-2 gap-5">
+                  <Input type="text" placeholder="Firstname" />
+                  <Input type="text" placeholder="Surname" />
+                </div>
+                <Input placeholder="Enter your email" type="email" />
+                <Input placeholder="Enter your password" type="password" />
+                <Input placeholder="Re-enter your password" type="password" />
+              </div>
+              <div className="mt-5 flex gap-3 items-center">
+                <input title="I accept" type="checkbox" className="border border-gray-400" />
+                <span>
+                  I accept the{" "}
+                  <a href="#" className="text-stone-500 font-semibold">
+                    Terms of Use
+                  </a>{" "}
+                  &{" "}
+                  <a href="#" className="text-stone-500 font-semibold">
+                    Privacy Policy
+                  </a>
+                </span>
+              </div>
+              <div className="pt-5">
+                <Button className="w-full" size={"sm"} type="submit" variant={"default"}>
+                  Register Now
+                </Button>
+              </div>
+            </form>
+            <LoginWithGoogle />
+          </div>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
🐛 Fixed Issues
#116 #117 

🛠 Changes
Replaced Input and Button components with shadcn/UI Components on Signup Page, similar to signin page.
Refactor some styling to make the signup layout consistent with signin layout.
Added a Google login button on signup page similar to the signin page. Refactored the google login into a separate shared component.

📝 Notes for Reviewers
Check the screenshot from testing on dev environment
![Screenshot_23](https://github.com/prasenjeet-symon/intellectia/assets/57339638/a8ead00e-17f7-434c-b642-3937e69540ae)