### PR TITLE
 added a new function to convert markdown to html

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "showdown": "^2.1.0"
+  }
 }

--- a/packages/server/src/seeder/utils.ts
+++ b/packages/server/src/seeder/utils.ts
@@ -1,3 +1,6 @@
+import * as readFileFs from 'fs';
+const showdown  = require('showdown')
+
 /**
  * Parse the Markdown file to JSON
  */
@@ -13,13 +16,17 @@ export async function markdownToJSON() {
 /**
  * Parse the Markdown to HTML
  */
-export async function markdownToHTML() {
-    // Markdown file is located in the assets folder
-    // markdown file is a article about the cat journey to the moon.
-    // read the markdown and convert it to HTML
-    // return the actual HTML string as { HTML: string }
-    // comment the library used for this purpose in the related issue on GitHub
-    // if you can write the pure TypeScript function for this purpose then awesome . :) You are really awesome !
+// used showdown (https://www.npmjs.com/package/showdown)
+export async function markdownToHTML(inputPath: string) {
+    try {
+        const data: string = readFileFs.readFileSync(inputPath, 'utf8');
+        const converter = new showdown.Converter();
+        const result = converter.makeHtml(data);
+        return { HTML: result };
+    } catch(error: any) {
+        console.error(error.message);
+        process.exit(-1);
+    }
 }
 
 /**


### PR DESCRIPTION
fixes #147 

- used [showdown](https://www.npmjs.com/package/showdown) library to convert .md to .html file.

Screenshot
<img width="1538" alt="Screenshot 2023-10-09 at 5 59 04 PM" src="https://github.com/prasenjeet-symon/intellectia/assets/75185537/36d9b9a4-b597-4790-9bfc-5d852aa3d4b3">

When there is no file
<img width="816" alt="Screenshot 2023-10-09 at 6 05 59 PM" src="https://github.com/prasenjeet-symon/intellectia/assets/75185537/e5fe9e92-61bf-4846-9716-25fddec9fd86">

