### PR TITLE
Update validator routes

### DIFF
--- a/lib/utils/__tests__/server/validators-route.ts
+++ b/lib/utils/__tests__/server/validators-route.ts
@@ -715,6 +715,19 @@ router.get(
 /**
  * apiRequestGETUserFollowingsValidator
  */
+/**
+ * apiRequestGETUserFollowingsSuggestSizeValidator
+ */
+router.get(
+  "/server/api/user/followings/suggest/:size",
+  apiRequestGETUserFollowingsSuggestSizeValidator,
+  async (_req, res) => {
+    res.status(200).json({
+      message: "Valid input",
+      reqClientData: res.locals.reqClientData,
+    });
+  }
+);
 router.get(
   "/server/api/user/followings/:size/:cursor",
   apiRequestGETUserFollowingsValidator,
@@ -752,20 +765,6 @@ router.get(
     });
   }
 );
-/**
- * apiRequestGETUserFollowingsSuggestSizeValidator
- */
-router.get(
-  "/server/api/user/followings/suggest/:size",
-  apiRequestGETUserFollowingsSuggestSizeValidator,
-  async (_req, res) => {
-    res.status(200).json({
-      message: "Valid input",
-      reqClientData: res.locals.reqClientData,
-    });
-  }
-);
-
 /**
  * apiRequestPUTUserFollowingsSuggestValidator
  */


### PR DESCRIPTION
Updated validator-route.ts to ensure "/server/api/user/followings/suggest/:size" is run before "/server/api/user/followings/:size/:cursor" so that there are no route clashes.

ISSUE SOLVED:
_Bug Fixes for apiRequestGETUserFollowingsSuggestSizeValidator in Validators Tests #218_
https://github.com/prasenjeet-symon/intellectia/issues/218