### PR TITLE
Feature/magic login

### DIFF
--- a/packages/server/src/api_auth/index.ts
+++ b/packages/server/src/api_auth/index.ts
@@ -145,7 +145,6 @@ router.post('/login', apiRequestAuthLoginValidator, async (req, res) => {
         res.status(500).json(response);
         return;
     }
-
 });
 
 /**
@@ -168,7 +167,7 @@ router.post('/signup', apiRequestAuthSignupValidator, async (req, res) => {
         if (oldUser) {
             const response:ApiResponse<null> = {
                 success : false,
-                status:409,
+                status: 409,
                 error:'A account already exists with this email.'
             }
             res.status(500).json(response);
@@ -226,8 +225,8 @@ router.post('/signup', apiRequestAuthSignupValidator, async (req, res) => {
         if (error instanceof ZodError && !error.isEmpty) {
             const response:ApiResponse<null> ={
                 success : false,
-                status:400,
-                error:error.issues[0]?.message
+                status: 400,
+                error: error.issues[0]?.message
             }
             return res.status(400).send(response);
             

--- a/packages/server/src/api_auth/index.ts
+++ b/packages/server/src/api_auth/index.ts
@@ -33,16 +33,6 @@ router.get('/', (_req, res) => {
     return;
 });
 
-router.get('/magic_login', (_req, res) => {
-    const response:ApiResponse<null> =  {
-       success: true,
-       status:200,
-       message:'Hello'
-    }
-    res.status(200).send(response);
-    return;
-});
-
 /**
  * Authenticate user with email and password
  * POSTMAN_DONE : This route is successfully added to postman and documented    


### PR DESCRIPTION
The "/magic_login" route is successfully refactored to use res.locals.reqClientData and within a try and catch block. I couldn't test it